### PR TITLE
Fixed processor bug, related to crash of processing windows

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,6 +155,7 @@ async def watermark_task(window_manager: TimeWindowManager) -> None:
 async def main():
     global kafka_bridge
     shutdown_event = asyncio.Event()
+    watermark_task_handle = None
 
     try:
         kafka_bridge = PyKafBridge("", hostname=KAFKA_HOST, port=KAFKA_PORT)

--- a/src/time_window_manager.py
+++ b/src/time_window_manager.py
@@ -1,6 +1,7 @@
 import logging
 import asyncio
 from collections import defaultdict
+from datetime import datetime
 from typing import Callable
 from src.profiles.processing_profile import ProcessingProfile
 from src.empty_window_strategy import EmptyWindowStrategy, SkipStrategy, KNNStrategy
@@ -161,17 +162,23 @@ class TimeWindowManager:
             # API error — skip this cell this tick, but preserve existing buffer
             return
 
-        # Step 2: Append new data to the window buffer
+        # Step 2: Normalize ISO timestamp strings to integer Unix timestamps
+        for record in new_data:
+            ts = record.get("timestamp")
+            if isinstance(ts, str):
+                record["timestamp"] = int(datetime.fromisoformat(ts).timestamp())
+
+        # Step 3: Append new data to the window buffer
         buf = self._get_or_create_buffer(cell_index)
         buf.append_slice(new_data)
 
-        # Step 3: Evict data older than window_start
+        # Step 4: Evict data older than window_start
         buf.evict_before(window_start)
 
-        # Step 4: Get the full buffered window
+        # Step 5: Get the full buffered window
         window_data = buf.get_all()
 
-        # Step 5: Process through profiles
+        # Step 6: Process through profiles
         is_empty: bool = len(window_data) == 0
         for profile in self.processing_profiles:
 


### PR DESCRIPTION
This pull request introduces improvements to fix a bug with the time window management logic. The most significant change is the normalization of ISO-formatted timestamp strings to Unix timestamps before buffering, ensuring consistent timestamp formats throughout the processing pipeline.

**Timestamp normalization and other improvements:**

* Added logic in `TimeWindowManager._process_cell_window` to convert ISO 8601 timestamp strings in incoming records to integer Unix timestamps before appending them to the buffer, ensuring consistent timestamp types for downstream processing.

* Initialized `watermark_task_handle` to `None` at the start of the `main` function in `main.py` for improved code clarity and to avoid potential reference errors.